### PR TITLE
Add contributing guidelines and code of conduct

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,0 +1,127 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Introduction
+
+Thank you for considering contributing to Cord! Community contributions are essential to keep the project healthy and sustainable.
+
+Following these guidelines helps to communicate that you respect the time of the developers managing and developing this open source project. Keep in mind that all contributions are done on a voluntary basis, including those of the project’s maintainers.
+
+## Contributions we are looking for
+
+There are many ways to contribute, from writing tutorials or blog posts, improving the documentation, submitting bug reports and feature requests, or directly by writing code which can be incorporated into the Cord project. Feel free to look at the list of [open issues](https://github.com/getcord/cord-preview/issues) and pick something that interests you that is not already assigned to someone.
+
+## Things we are not looking for
+
+Please, don't use the issue tracker for support questions. We have a [Discord server](https://discord.gg/Vgt5c26VwG) where you can ask questions and get help. If your problem is not strictly Cord-specific, Stack Overflow is also worth considering.
+
+## Contribution Guidelines
+
+This project is used by multiple companies and teams, so we have a few guidelines to follow when contributing.
+
+* All contributions must abide by the [Code of Conduct](CODE-OF-CONDUCT.md).
+* Ensure cross-browser compatibility for every change that's accepted. We try our best to support evergreen browsers such as Chromium based browsers, Firefox, and Safari.
+* Create issues for any major changes and enhancements that you wish to make. Discuss things transparently and get community feedback.
+* Keep pull requests as small as possible to make it easier for us to review and merge.
+* Be welcoming to newcomers and encourage diverse new contributors from all backgrounds.
+
+## Getting started
+
+Instructions for getting the project running locally, refer to the README. When you're ready to make your changes, follow these steps:
+
+1. Create your own fork of the code
+2. Do the changes in your fork
+3. If you like the change and think the project could use it, submit a pull request
+
+## How to report a bug
+
+If you find a security vulnerability, do NOT open an issue. Contact one of the project maintainers directly via the Discord server.
+
+When filing an issue, make sure you completely fill out the issue template. The more information you provide, the more likely someone will be able to help you. If you can provide a reproduction of the bug, it will be much easier to diagnose the problem.
+
+## How to suggest a feature or enhancement
+
+Feel free to create an issue with the `enhancement` label and fill it out with as much detail as possible. There is no guarantee that a feature request will be accepted, but we will try to respond to it as quickly as possible. Always remember that the maintainers of this project are volunteers and are not paid to work on this project.
+
+## Code review process
+
+The core team will try to review Pull Requests as soon as they're able. After feedback has been given we expect responses within two weeks. After two weeks we may close the pull request if it isn't showing any activity.
+
+## Community
+
+Join the [Discord server](https://discord.gg/Vgt5c26VwG) to chat with the core team and other contributors as well as the rest of the community. It's a great place to ask questions, get help, and share your ideas.


### PR DESCRIPTION
This is an initial stab at contributing guidelines and a code of conduct. These were based off of other open source examples.